### PR TITLE
Removed all references to OPENSTACK_* settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ nosetests.xml
 .project
 .pydevproject
 
+env/*
 *.log
 logs/*
 scripts/*

--- a/rtwo/accounts/openstack.py
+++ b/rtwo/accounts/openstack.py
@@ -30,11 +30,7 @@ class AccountDriver():
 
     def __init__(self, *args, **kwargs):
         network_args = {}
-        network_args.update(settings.OPENSTACK_ARGS)
-        network_args.update(settings.OPENSTACK_NETWORK_ARGS)
 
-        self.user_manager = UserManager(**settings.OPENSTACK_ARGS.copy())
-        self.network_manager = NetworkManager(**network_args)
 
     def get_openstack_clients(self, username, password=None, tenant_name=None):
 
@@ -56,7 +52,7 @@ class AccountDriver():
         }
 
     def _get_horizon_url(self, tenant_id):
-        parsed_url = urlparse(settings.OPENSTACK_AUTH_URL)
+        parsed_url = urlparse("")
         return 'https://%s/horizon/auth/switch/%s/?next=/horizon/project/' %\
             (parsed_url.hostname, tenant_id)
 
@@ -68,10 +64,7 @@ class AccountDriver():
         finished = False
         # Special case for admin.. Use the Openstack admin identity..
         if username == 'admin':
-            ident = self.create_openstack_identity(
-                settings.OPENSTACK_ADMIN_KEY,
-                settings.OPENSTACK_ADMIN_SECRET,
-                settings.OPENSTACK_ADMIN_TENANT)
+            ident = self.create_openstack_identity('','','')
             return ident
         #Attempt account creation
         while not finished:
@@ -167,8 +160,7 @@ class AccountDriver():
         usergroups = []
         for group in groups:
             for user in users:
-                if user.name in group.name and\
-                   settings.OPENSTACK_ADMIN_KEY not in user.name:
+                if user.name in group.name:
                     usergroups.append((user, group))
                     break
         return usergroups

--- a/rtwo/driver.py
+++ b/rtwo/driver.py
@@ -367,7 +367,7 @@ class OSDriver(EshDriver, InstanceActionMixin):
         """
         DEPRECATED:
         """
-        os_args = copy.deepcopy(settings.OPENSTACK_ARGS)
+        os_args = {}
         try:
             username = os_args.pop('username')
             password = os_args.pop('password')
@@ -380,8 +380,7 @@ class OSDriver(EshDriver, InstanceActionMixin):
         OSProvider.set_meta()
         provider = OSProvider()
         identity = OSIdentity(provider, username, password,
-                              ex_tenant_name=tenant_name,
-                              **settings.OPENSTACK_ARGS)
+                              ex_tenant_name=tenant_name)
         driver = cls(provider, identity)
         return driver
 

--- a/rtwo/meta.py
+++ b/rtwo/meta.py
@@ -156,13 +156,16 @@ class OSMeta(Meta):
     provider = OSProvider
 
     def create_admin_driver(self, creds=None):
+        """
+        DEPRECATED
+        """
         admin_provider = OSProvider()
         provider_creds = self.provider_options
         key, secret, tenant =\
             self._split_creds(creds,
-                              settings.OPENSTACK_ADMIN_KEY,
-                              settings.OPENSTACK_ADMIN_SECRET,
-                              settings.OPENSTACK_ADMIN_TENANT)
+                              '',
+                              '',
+                              '')
         admin_identity = OSIdentity(admin_provider,
                                     key,
                                     secret,

--- a/rtwo/settings.py
+++ b/rtwo/settings.py
@@ -29,13 +29,6 @@ if not settings:
     class Settings(object):
         pass
     settings = Settings()
-    settings.OPENSTACK_ADMIN_KEY = ""
-    settings.OPENSTACK_ADMIN_SECRET = ""
-    settings.OPENSTACK_AUTH_URL = ""
-    settings.OPENSTACK_ADMIN_URL = ""
-    settings.OPENSTACK_ADMIN_TENANT = ""
-    settings.OPENSTACK_DEFAULT_REGION = ""
-    settings.OPENSTACK_DEFAULT_ROUTER = ""
     settings.EUCA_ADMIN_KEY = ""
     settings.EUCA_ADMIN_SECRET = ""
     settings.SERVER_URL = ""
@@ -44,19 +37,8 @@ if not settings:
 
 
 def set_settings(settings):
-    global OPENSTACK_ADMIN_KEY, OPENSTACK_ADMIN_SECRET,\
-        OPENSTACK_AUTH_URL, OPENSTACK_ADMIN_URL,\
-        OPENSTACK_ADMIN_TENANT, OPENSTACK_DEFAULT_REGION,\
-        OPENSTACK_DEFAULT_ROUTER, EUCA_ADMIN_KEY,\
-        EUCA_ADMIN_SECRET, SERVER_URL,\
+    global EUCA_ADMIN_KEY, EUCA_ADMIN_SECRET, SERVER_URL,\
         INSTANCE_SERVICE_URL, ATMOSPHERE_VNC_LICENSE
-    OPENSTACK_ADMIN_KEY = settings.OPENSTACK_ADMIN_KEY
-    OPENSTACK_ADMIN_SECRET = settings.OPENSTACK_ADMIN_SECRET
-    OPENSTACK_AUTH_URL = settings.OPENSTACK_AUTH_URL
-    OPENSTACK_ADMIN_URL = settings.OPENSTACK_ADMIN_URL
-    OPENSTACK_ADMIN_TENANT = settings.OPENSTACK_ADMIN_TENANT
-    OPENSTACK_DEFAULT_REGION = settings.OPENSTACK_DEFAULT_REGION
-    OPENSTACK_DEFAULT_ROUTER = settings.OPENSTACK_DEFAULT_ROUTER
     EUCA_ADMIN_KEY = settings.EUCA_ADMIN_KEY
     EUCA_ADMIN_SECRET = settings.EUCA_ADMIN_SECRET
     SERVER_URL = settings.SERVER_URL
@@ -64,17 +46,3 @@ def set_settings(settings):
     ATMOSPHERE_VNC_LICENSE = settings.ATMOSPHERE_VNC_LICENSE
 
 set_settings(settings)
-
-OPENSTACK_ARGS = {
-    'username': OPENSTACK_ADMIN_KEY,
-    'password': OPENSTACK_ADMIN_SECRET,
-    'tenant_name': OPENSTACK_ADMIN_TENANT,
-    'auth_url': OPENSTACK_ADMIN_URL,
-    'region_name': OPENSTACK_DEFAULT_REGION
-}
-
-OPENSTACK_NETWORK_ARGS = {
-    'auth_url': OPENSTACK_ADMIN_URL,
-    'region_name': OPENSTACK_DEFAULT_REGION,
-    'router_name': OPENSTACK_DEFAULT_ROUTER
-}

--- a/rtwo/test_settings.py.dist
+++ b/rtwo/test_settings.py.dist
@@ -7,30 +7,6 @@ import threepio
 
 import rtwo
 
-
-# Openstack provider secrets
-OPENSTACK_ADMIN_KEY=""
-OPENSTACK_ADMIN_SECRET=""
-OPENSTACK_AUTH_URL=""
-OPENSTACK_ADMIN_URL=""
-OPENSTACK_ADMIN_TENANT=""
-OPENSTACK_DEFAULT_REGION=""
-OPENSTACK_DEFAULT_ROUTER=""
-
-# Openstack provider dictionaries
-OPENSTACK_ARGS = {
-    'username': OPENSTACK_ADMIN_KEY,
-    'password': OPENSTACK_ADMIN_SECRET,
-    'tenant_name': OPENSTACK_ADMIN_TENANT,
-    'auth_url': OPENSTACK_ADMIN_URL,
-    'region_name': OPENSTACK_DEFAULT_REGION
-}
-OPENSTACK_NETWORK_ARGS = {
-    'auth_url': OPENSTACK_ADMIN_URL,
-    'region_name': OPENSTACK_DEFAULT_REGION,
-    'router_name': OPENSTACK_DEFAULT_ROUTER
-}
-
 LOGGING_LEVEL = logging.INFO
 DEP_LOGGING_LEVEL = logging.WARN # Logging level for dependencies.
 LOG_FILENAME = os.path.abspath(os.path.join(


### PR DESCRIPTION
The notion of a 'single' set of settings (settings.OPENSTACK_*) does
not fit into a multi-provider scenario. Relates to Atmosphere PR 168[1]

[1] https://github.com/iPlantCollaborativeOpenSource/atmosphere/pull/168